### PR TITLE
Safe guard for getModule if config contains disabled modules

### DIFF
--- a/MMM-Touch.js
+++ b/MMM-Touch.js
@@ -726,7 +726,7 @@ class GestureCommander {
     var modules = this.getModules()
     if (mName == null) mName = "MMM-Touch"
     for (var i = 0; i < modules.length; i++) {
-      if (modules[i].name == mName) return modules[i]
+      if (modules[i] && modules[i].name == mName) return modules[i]
     }
   }
 


### PR DESCRIPTION
I had multiple disabled modules in my config. This made most indexes in the array undefined.

![image](https://user-images.githubusercontent.com/9334168/96386664-e3d6af00-119c-11eb-95b7-257f20a9e208.png)
